### PR TITLE
Version bump to 0.0.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from codecs import open
 
 setup(
 	name='commonmarkextensions',
-	version='0.0.5',
+	version='0.0.6',
 
 	description='Tables and plain text rendering extension to commonmark.',
 	long_description=open("README.md", encoding='utf-8').read(),


### PR DESCRIPTION
Allows a pip install to pick up the changes (I think) recently added to allow support for the newer version of commonmark