### PR TITLE
Add support for colspan

### DIFF
--- a/commonmark_extensions/tables.py
+++ b/commonmark_extensions/tables.py
@@ -171,7 +171,7 @@ class Table(commonmark.blocks.Block):
         for part in table_parts:
             for row in part:
                 for i, cell in enumerate(row):
-                    row[i] = inner_parser(cell)
+                    row[i] = inner_parser(cell) if cell != "-" else None
 
         # Store the parsed table on the node.
         block.column_properties = column_properties
@@ -211,6 +211,9 @@ class RendererWithTables(commonmark.HtmlRenderer):
                 for row in part:
                     self.lit("<tr>\n")
                     for colidx, cell in enumerate(row):
+                        if cell is None:
+                            continue
+
                         if part_tag == "thead":
                             col_tag = "th"
                             if self.options.get("table_th_scope"):
@@ -223,6 +226,15 @@ class RendererWithTables(commonmark.HtmlRenderer):
 
                         if colidx in node.column_properties and "align" in node.column_properties[colidx]:
                             col_attrs += ' align=\"' + node.column_properties[colidx]["align"] + "\""
+
+                        span = 1
+                        for nextid in range(colidx+1, len(row)):
+                            if row[nextid] is None:
+                                span += 1
+                            else:
+                                break
+                        if span > 1:
+                            col_attrs += ' colspan=\"' + str(span) + '\"'
 
                         self.lit("<" + col_tag + col_attrs + ">")
                         

--- a/commonmark_extensions/tables.py
+++ b/commonmark_extensions/tables.py
@@ -143,6 +143,8 @@ class Table(commonmark.blocks.Block):
                 # Multline mode. Merge this row with the previous one.
                 for i in range(len(row)):
                     if i < len(table_parts[-1][-1]):
+                        if table_parts[-1][-1][i] == "-":
+                            continue
                         table_parts[-1][-1][i] += "\n" + row[i]
                     else:
                         table_parts[-1][-1].append(row[i])

--- a/commonmark_extensions/tests.py
+++ b/commonmark_extensions/tests.py
@@ -196,6 +196,69 @@ bar""",
 </thead>
 </table>""")
 
+    def test_colspan_header(self):
+        self.assertRender(
+"""| foo | - |
+| --- | --- |
+| baz | bim |""",
+
+"""<table>
+<thead>
+<tr>
+<th colspan="2">foo</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>baz</td>
+<td>bim</td>
+</tr>
+</tbody>
+</table>"""
+        )
+
+    def test_colspan_body(self):
+        self.assertRender(
+"""| foo | bar |
+| --- | --- |
+| baz | - |""",
+
+"""<table>
+<thead>
+<tr>
+<th>foo</th>
+<th>bar</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2">baz</td>
+</tr>
+</tbody>
+</table>"""
+        )
+
+    def test_colspan_multiple(self):
+        self.assertRender(
+"""| foo | bar | - |- | -|
+| --- | --- | --- | --- | --- |
+| baz | - | bim | - |-|""",
+
+"""<table>
+<thead>
+<tr>
+<th>foo</th>
+<th colspan="4">bar</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2">baz</td>
+<td colspan="3">bim</td>
+</tr>
+</tbody>
+</table>"""
+        )
             
 class MultilineTablesTests(unittest.TestCase):
     """Test the multiline cell mode."""
@@ -236,6 +299,98 @@ bim</p>
 </table>"""            
         )
         
+    def test_colspan_header(self):
+        self.assertRender(
+"""| foo | - |
+| === | === |
+| baz | bim |
+| baz | bim |""",
+
+"""<table>
+<thead>
+<tr>
+<th colspan="2">foo</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><p>baz
+baz</p>
+</td>
+<td><p>bim
+bim</p>
+</td>
+</tr>
+</tbody>
+</table>"""
+        )
+
+    def test_colspan_body(self):
+        self.assertRender(
+"""| foo | bar |
+| === | === |
+| baz | - |""",
+
+"""<table>
+<thead>
+<tr>
+<th>foo</th>
+<th>bar</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2">baz</td>
+</tr>
+</tbody>
+</table>"""
+        )
+
+    def test_colspan_multiple(self):
+        self.assertRender(
+"""| foo | bar | - |- | -|
+| === | === | === | === | === |
+| baz | - | bim | - |-|""",
+
+"""<table>
+<thead>
+<tr>
+<th>foo</th>
+<th colspan="4">bar</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2">baz</td>
+<td colspan="3">bim</td>
+</tr>
+</tbody>
+</table>"""
+        )
+
+    def test_colspan_multiline_body(self):
+        self.assertRender(
+"""| foo | bar |
+| === | === |
+| baz | - |
+| baz | |""",
+
+"""<table>
+<thead>
+<tr>
+<th>foo</th>
+<th>bar</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2"><p>baz
+baz</p>
+</td>
+</tr>
+</tbody>
+</table>"""
+        )
 
 class PlainTextRendererTests(unittest.TestCase):
     """Test the PlainTextRenderer cell mode."""


### PR DESCRIPTION
This adds support for having colspan generated in tables. The spec is yet to be updated with GFM.

A cell with the sole contents of `-` will be ignored, and previous cells in the row will have a colspan attribute.

Side effect would be that users can't have a cell with just `-` in it.

Fixes #10 